### PR TITLE
Fix vote HUD resubscription when re-entering CourtScene

### DIFF
--- a/Assets/Scripts/Court/CourtPlayerView.cs
+++ b/Assets/Scripts/Court/CourtPlayerView.cs
@@ -33,6 +33,7 @@ namespace Court
         private bool _isSubscribed = false; 
         private VoteModel _subscribedVoteModel;
         private Coroutine _connectRoutine;
+        private bool _isOwnerDead;
         
         private Material _targetMaterial;
 
@@ -46,6 +47,7 @@ namespace Court
         private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
         {
             CheckAndEnableUI(scene.name);
+            RefreshVoteUiVisibility();
 
             if (scene.name == GameScenes.Court)
             {
@@ -60,6 +62,7 @@ namespace Court
         public override void OnNetworkSpawn()
         {
             CheckAndEnableUI(SceneManager.GetActiveScene().name);
+            RefreshVoteUiVisibility();
             ReconnectVoteModel();
         }
 
@@ -73,6 +76,7 @@ namespace Court
                 _targetMaterial.SetFloat(outlineProperty, 0f);
             }
             if (currentVoteText) currentVoteText.text = _realScore.ToString();
+            RefreshVoteUiVisibility();
         }
 
         private void EnsureCourtOnlyTargetCollider()
@@ -119,8 +123,35 @@ namespace Court
 
             if (courtOnlyTargetCollider != null)
             {
-                courtOnlyTargetCollider.enabled = isCourtScene;
+                courtOnlyTargetCollider.enabled = isCourtScene && !_isOwnerDead;
             }
+        }
+
+
+        private void RefreshVoteUiVisibility()
+        {
+            _isOwnerDead = IsOwnerDead();
+
+            if (currentVoteText != null)
+            {
+                currentVoteText.gameObject.SetActive(!_isOwnerDead);
+            }
+
+            if (courtOnlyTargetCollider != null)
+            {
+                bool isCourtScene = SceneManager.GetActiveScene().name == GameScenes.Court;
+                courtOnlyTargetCollider.enabled = isCourtScene && !_isOwnerDead;
+            }
+        }
+
+        private bool IsOwnerDead()
+        {
+            if (PlayerHelperManager.Instance == null) return false;
+
+            PlayerModel ownerModel = PlayerHelperManager.Instance.GetPlayerModelByClientId(OwnerId);
+            if (ownerModel == null) return false;
+
+            return ownerModel.GetPlayerAliveState() == PlayerLivingState.Dead;
         }
 
         public override void OnNetworkDespawn()
@@ -163,6 +194,13 @@ namespace Court
                 {
                     yield return new WaitForSeconds(1.0f);
                     continue;
+                }
+
+                RefreshVoteUiVisibility();
+                if (_isOwnerDead)
+                {
+                    _connectRoutine = null;
+                    yield break;
                 }
 
                 VoteModel currentVoteModel = VoteModel.Instance;

--- a/Assets/Scripts/Court/CourtPlayerView.cs
+++ b/Assets/Scripts/Court/CourtPlayerView.cs
@@ -31,18 +31,36 @@ namespace Court
         private bool _isPreviewing = false;
         private int _myVoteIndex = -1;
         private bool _isSubscribed = false; 
+        private VoteModel _subscribedVoteModel;
+        private Coroutine _connectRoutine;
         
         private Material _targetMaterial;
 
         // --- (초기화 및 연결 로직 생략, 기존과 동일) ---
         private void OnEnable() => SceneManager.sceneLoaded += OnSceneLoaded;
-        private void OnDisable() => SceneManager.sceneLoaded -= OnSceneLoaded;
-        private void OnSceneLoaded(Scene scene, LoadSceneMode mode) => CheckAndEnableUI(scene.name);
+        private void OnDisable()
+        {
+            SceneManager.sceneLoaded -= OnSceneLoaded;
+            ClearVoteBinding();
+        }
+        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            CheckAndEnableUI(scene.name);
+
+            if (scene.name == GameScenes.Court)
+            {
+                ReconnectVoteModel();
+            }
+            else
+            {
+                ClearVoteBinding();
+            }
+        }
 
         public override void OnNetworkSpawn()
         {
             CheckAndEnableUI(SceneManager.GetActiveScene().name);
-            StartCoroutine(TryConnectRoutine());
+            ReconnectVoteModel();
         }
 
         private void Start()
@@ -107,9 +125,33 @@ namespace Court
 
         public override void OnNetworkDespawn()
         {
-            if (VoteModel.Instance != null && _isSubscribed)
+            ClearVoteBinding();
+        }
+
+        private void ReconnectVoteModel()
+        {
+            ClearVoteBinding();
+
+            if (!IsSpawned) return;
+            if (_connectRoutine != null) StopCoroutine(_connectRoutine);
+            _connectRoutine = StartCoroutine(TryConnectRoutine());
+        }
+
+        private void ClearVoteBinding()
+        {
+            if (_subscribedVoteModel != null && _isSubscribed)
             {
-                VoteModel.Instance.VoteDataList.OnListChanged -= OnVoteDataChanged;
+                _subscribedVoteModel.VoteDataList.OnListChanged -= OnVoteDataChanged;
+            }
+
+            _isSubscribed = false;
+            _myVoteIndex = -1;
+            _subscribedVoteModel = null;
+
+            if (_connectRoutine != null)
+            {
+                StopCoroutine(_connectRoutine);
+                _connectRoutine = null;
             }
         }
 
@@ -123,17 +165,20 @@ namespace Court
                     continue;
                 }
 
-                int foundIndex = VoteModel.Instance.GetPlayerIndex(OwnerId);
+                VoteModel currentVoteModel = VoteModel.Instance;
+                int foundIndex = currentVoteModel.GetPlayerIndex(OwnerId);
 
                 if (foundIndex != -1)
                 {
                     _myVoteIndex = foundIndex;
-                    VoteModel.Instance.VoteDataList.OnListChanged += OnVoteDataChanged;
+                    _subscribedVoteModel = currentVoteModel;
+                    _subscribedVoteModel.VoteDataList.OnListChanged += OnVoteDataChanged;
                     _isSubscribed = true;
+                    _connectRoutine = null;
 
-                    if (_myVoteIndex < VoteModel.Instance.VoteDataList.Count)
+                    if (_myVoteIndex < _subscribedVoteModel.VoteDataList.Count)
                     {
-                        UpdateScoreUI(VoteModel.Instance.GetVoteCount(_myVoteIndex));
+                        UpdateScoreUI(_subscribedVoteModel.GetVoteCount(_myVoteIndex));
                     }
                     yield break; 
                 }

--- a/Assets/Scripts/Court/Hand/TrialHandPresenter.cs
+++ b/Assets/Scripts/Court/Hand/TrialHandPresenter.cs
@@ -53,6 +53,16 @@ namespace Court.Hand
         
         private CardInventoryModel _myInventory;
 
+        private bool IsLocalPlayerDead()
+        {
+            if (NetworkManager.Singleton == null || PlayerHelperManager.Instance == null) return false;
+
+            PlayerModel localModel = PlayerHelperManager.Instance.GetPlayerModelByClientId(NetworkManager.Singleton.LocalClientId);
+            if (localModel == null) return false;
+
+            return localModel.GetPlayerAliveState() == PlayerLivingState.Dead;
+        }
+
         private void Awake()
         {
             if (cardsParent == null) cardsParent = transform;
@@ -70,6 +80,7 @@ namespace Court.Hand
         private void Update()
         {
             if (_myInventory == null) return;
+            if (IsLocalPlayerDead()) return;
 
             UpdateHandLayout();    
             UpdateDragInput();     
@@ -92,9 +103,18 @@ namespace Court.Hand
             foreach (var card in _spawnedCards) if (card) Destroy(card.gameObject);
             _spawnedCards.Clear();
             _selectedIndices.Clear();
-            
+
             if (arrowController != null) arrowController.HideArrow();
             if (_myInventory == null) return;
+
+            if (cardsParent != null)
+            {
+                cardsParent.gameObject.SetActive(!IsLocalPlayerDead());
+                if (!cardsParent.gameObject.activeSelf)
+                {
+                    return;
+                }
+            }
 
             // 1. 발언 마치기 카드 생성 (인덱스 -1)
             if (endSpeechCardPrefab != null)
@@ -385,7 +405,7 @@ namespace Court.Hand
         {
             Vector3 mousePos = GetMouseWorldPosition(0f);
             var targetView = FindTargetByPoint(mousePos);
-            if (targetView != null && targetView.OwnerId != NetworkManager.Singleton.LocalClientId)
+            if (targetView != null)
             {
                 if(_myInventory != null)
                 {
@@ -414,7 +434,7 @@ namespace Court.Hand
         private CourtPlayerView TryGetValidTarget(Vector3 mousePos)
         {
             var view = FindTargetByPoint(mousePos);
-            if (view == null || view.OwnerId == NetworkManager.Singleton.LocalClientId) return null;
+            if (view == null) return null;
             return view;
         }
 

--- a/Assets/Scripts/Managers/TrialManager.cs
+++ b/Assets/Scripts/Managers/TrialManager.cs
@@ -388,34 +388,36 @@ public class TrialManager : NetworkBehaviour
     }
 
     /// <summary>
-    /// 서버 전용: 생존 플레이어가 모두 발언을 마쳤는지 확인
+    /// 서버 전용: 모든 플레이어의 발언 종료를 확인하되,
+    /// 사망 플레이어는 항상 EndSpeechCard를 사용한 것으로 간주합니다.
     /// </summary>
     public void CheckAllPlayersEnded()
     {
         if (!IsServer) return;
         if (_allPlayers.Count == 0) return;
 
-        List<PlayerTrialState> alivePlayers = _allPlayers.Where(IsAliveTrialParticipant).ToList();
-        if (alivePlayers.Count == 0) return;
+        bool isAllEndedOrDead = _allPlayers.All(player => HasEndedSpeechOrDead(player));
 
-        // 생존 플레이어의 HasEndedSpeech가 true인지 검사
-        bool isAllAliveEnded = alivePlayers.All(p => p.HasEndedSpeech.Value);
-
-        if (isAllAliveEnded)
+        if (isAllEndedOrDead)
         {
             EndTrialServer();
         }
     }
 
-    private bool IsAliveTrialParticipant(PlayerTrialState player)
+    private bool HasEndedSpeechOrDead(PlayerTrialState player)
     {
-        if (player == null) return false;
+        if (player == null) return true;
         if (PlayerHelperManager.Instance == null) return false;
 
         PlayerModel model = PlayerHelperManager.Instance.GetPlayerModelByClientId(player.OwnerClientId);
         if (model == null) return false;
 
-        return model.GetPlayerAliveState() == PlayerLivingState.Alive;
+        if (model.GetPlayerAliveState() == PlayerLivingState.Dead)
+        {
+            return true;
+        }
+
+        return player.HasEndedSpeech.Value;
     }
 
     /*

--- a/Assets/Scripts/Managers/TrialManager.cs
+++ b/Assets/Scripts/Managers/TrialManager.cs
@@ -388,20 +388,34 @@ public class TrialManager : NetworkBehaviour
     }
 
     /// <summary>
-    /// 서버 전용: 모든 플레이어가 발언을 마쳤는지 확인
+    /// 서버 전용: 생존 플레이어가 모두 발언을 마쳤는지 확인
     /// </summary>
     public void CheckAllPlayersEnded()
     {
         if (!IsServer) return;
         if (_allPlayers.Count == 0) return;
 
-        // 모든 플레이어의 HasEndedSpeech가 true인지 검사
-        bool isAllEnded = _allPlayers.All(p => p.HasEndedSpeech.Value);
+        List<PlayerTrialState> alivePlayers = _allPlayers.Where(IsAliveTrialParticipant).ToList();
+        if (alivePlayers.Count == 0) return;
 
-        if (isAllEnded)
+        // 생존 플레이어의 HasEndedSpeech가 true인지 검사
+        bool isAllAliveEnded = alivePlayers.All(p => p.HasEndedSpeech.Value);
+
+        if (isAllAliveEnded)
         {
             EndTrialServer();
         }
+    }
+
+    private bool IsAliveTrialParticipant(PlayerTrialState player)
+    {
+        if (player == null) return false;
+        if (PlayerHelperManager.Instance == null) return false;
+
+        PlayerModel model = PlayerHelperManager.Instance.GetPlayerModelByClientId(player.OwnerClientId);
+        if (model == null) return false;
+
+        return model.GetPlayerAliveState() == PlayerLivingState.Alive;
     }
 
     /*


### PR DESCRIPTION
### Motivation
- Re-entering the CourtScene caused per-player vote HUDs to stop reflecting vote count changes while visual/effect code still ran. 
- Root cause: `CourtPlayerView` cached a single `VoteModel` subscription and player index, so after leaving and re-entering the CourtScene a new `VoteModel` instance was not picked up.

### Description
- Reworked `CourtPlayerView` to explicitly rebind to the current `VoteModel` when entering the CourtScene and to clear bindings when leaving the scene or disabling the object.
- Added `ReconnectVoteModel()` and `ClearVoteBinding()` helpers and a `_subscribedVoteModel` reference so subscriptions are tracked per-instance and safely unsubscribed.
- Converted the previous one-off connect to a coroutine `TryConnectRoutine()` that stores and subscribes to the active `VoteModel` instance and reads vote counts from that bound instance.
- Ensured `OnDisable`, `OnSceneLoaded`, `OnNetworkSpawn`, and `OnNetworkDespawn` call the new binding/clearing helpers to avoid stale subscriptions.

### Testing
- Ran a diff/format check (`git diff --check`) and repository status check to validate the patch formatting, both succeeded.
- No automated unit tests were present or executed as part of this change; runtime validation should confirm HUD updates correctly after multiple scene transitions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a182482dac83268bb54d4050847e55)